### PR TITLE
Fixed bug caused by calling Poison.encode! on an empty request body

### DIFF
--- a/lib/togglex.ex
+++ b/lib/togglex.ex
@@ -52,7 +52,8 @@ defmodule Togglex do
   end
 
   def json_request(method, url, body \\ "", headers \\ [], options \\ []) do
-    request!(method, url, Poison.encode!(body), headers, options) |> process_response
+    body = if String.trim(body) == "", do: body, else: Poison.encode!(body)
+    request!(method, url, body, headers, options) |> process_response
   end
 
   @spec authorization_header(Client.auth, list) :: list


### PR DESCRIPTION
In `Togglex.json_request`, the argument `body` is encoded to JSON using the `Poison.encode!` function. The default value for this argument is an empty string (`""`).

Calling `Poison.encode!` on an empty string returns `"\"\""`. In the past, Toggl's servers would process requests issued with this request body without issue. However, sometime within the last few months, the behavior of the API changed. Now when a request is submitted to Toggl with this value in the request body, Toggl returns an HTML page with an "invalid request" message.

This results in a `:connect_timeout` exception being raised (in version 0.2.0 of Togglex) when calling certain functions, such as `Togglex.Reports.summary`. (In version 0.1.0, a "Unexpected token" exception is raised.)

This pull request adds a check in the `Togglex.json_request` function that skips the call to `Poison.encode!` if `body` is empty.